### PR TITLE
[FINAL] Adding `nearestTValue` and `indexOfNearestPoint` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v 1.1.0 - January 30 2019
 
-- Added `nearestTValue` method to `Bezier` class
+- Added `nearestTValue` method to `Bezier` class, based on work by @luigi-rosso -- Thanks!
 - Added `indexOfNearestPoint` method (to support `nearestTValue`) in `bezier_tools`
 - Added unit tests for both new methods in `bezier_nearest_methods_test`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - bezier
 
+## v 1.1.0 - January 30 2019
+
+- Added `nearestTValue` method to `Bezier` class
+- Added `indexOfNearestPoint` method (to support `nearestTValue`) in `bezier_tools`
+- Added unit tests for both new methods in `bezier_nearest_methods_test`
+
+## v 1.0.3 - December 20 2018
+
+- Corrected the version number in the pubspec, since I forgot to commit it in 1.0.2
+
 ## v 1.0.2 - December 20 2018
 
 - Added example directory with a simple HTML demo app

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -725,7 +725,22 @@ abstract class Bezier {
 
     return lookUpTable;
   }
-  
+
+  /// Returns the parameter value along the curve that is closest (in terms of
+  /// geometric distance) to the given [point].  The approximation uses a
+  /// two-pass projection test that relies on the curve's position look up
+  /// table.  First, the method determines the point in the look up table that
+  /// is closest to [point].  Afterward, it checks the fine interval around that
+  /// point to see if a better projection can be found.
+  ///
+  /// The optional parameter [cachedPositionLookUpTable] allows the method to
+  /// use previously calculated values for [positionLookUpTable] instead
+  /// of repeating the calculations.  The optional [stepSize] parameter
+  /// determines how much to increment the parameter value at each iteration
+  /// when searching the fine interval for the best projection.  The default
+  /// [stepSize] value of 0.1 means that the function will do around twenty
+  /// iterations.  Reducing the value of [stepSize] will increase the number of
+  /// iterations.
   double nearestTValue(Vector2 point, {List<Vector2> cachedPositionLookUpTable, double stepSize = 0.1}) {
     final lookUpTable = cachedPositionLookUpTable ?? positionLookUpTable();
 
@@ -749,7 +764,7 @@ abstract class Bezier {
     var t = t1;
     var minSquaredDistance = double.maxFinite;
     var nearestT = t1;
-
+    
     while (t < maxT) {
       final pointOnCurve = pointAt(t);
       final squaredDistance = point.distanceToSquared(pointOnCurve);

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -741,13 +741,14 @@ abstract class Bezier {
   /// [stepSize] value of 0.1 means that the function will do around twenty
   /// iterations.  Reducing the value of [stepSize] will increase the number of
   /// iterations.
-  double nearestTValue(Vector2 point, {List<Vector2> cachedPositionLookUpTable, double stepSize = 0.1}) {
+  double nearestTValue(Vector2 point,
+      {List<Vector2> cachedPositionLookUpTable, double stepSize = 0.1}) {
     final lookUpTable = cachedPositionLookUpTable ?? positionLookUpTable();
 
     final index = indexOfNearestPoint(lookUpTable, point);
 
     final maxIndex = lookUpTable.length - 1;
-    
+
     if (index == 0) {
       return 0.0;
     } else if (index == maxIndex) {

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -755,11 +755,11 @@ abstract class Bezier {
       return 1.0;
     }
 
-    final divisor = maxIndex.toDouble();
-    final t1 = (index - 1) / divisor;
-    final t2 = (index + 1) / divisor;
+    final intervalsCount = maxIndex.toDouble();
+    final t1 = (index - 1) / intervalsCount;
+    final t2 = (index + 1) / intervalsCount;
 
-    final tIncrement = stepSize / divisor;
+    final tIncrement = stepSize / intervalsCount;
     final maxT = t2 + tIncrement;
 
     var t = t1;

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -764,7 +764,7 @@ abstract class Bezier {
     var t = t1;
     var minSquaredDistance = double.maxFinite;
     var nearestT = t1;
-    
+
     while (t < maxT) {
       final pointOnCurve = pointAt(t);
       final squaredDistance = point.distanceToSquared(pointOnCurve);
@@ -779,66 +779,4 @@ abstract class Bezier {
 
     return nearestT;
   }
-
-  /// Returns a [ProjectionResult] object with the closest point to the closest off curve point 
-  /// provided as the [point] parameter.
-  ///
-  /// Finds the on-curve point closest to the specific off-curve point, using a two-pass projection 
-  /// test based on the curve's LUT. A distance comparison finds the closest match, after which a 
-  /// fine interval around that match is checked to see if a better projection can be found.
-  ProjectionResult project(Vector2 point) {
-    // coarse check
-    final List<Vector2> lookUpTable = positionLookUpTable(intervalsCount: 100);
-
-    // Find closest in LUT
-    double mdist = double.maxFinite;
-    int mpos = 0;
-    int length = lookUpTable.length;
-    for (int i = 0; i < length; i++) {
-      final Vector2 p = lookUpTable[i];
-      double d2 = p.distanceToSquared(point);
-      if (d2 < mdist) {
-        mdist = d2;
-        mpos = i;
-      }
-    }
-
-    if (mpos == 0 || mpos == length - 1) {
-      // At start/end
-      double t = mpos / (length - 1);
-
-      return ProjectionResult()
-        ..point = pointAt(t)
-        ..t = t
-        ..distance = sqrt(mdist);
-    }
-
-    // Fine check
-    Vector2 p;
-    int l = length - 1;
-    double d, t1 = (mpos - 1) / l, t2 = (mpos + 1) / l, step = 0.1 / l;
-    mdist += 1;
-    double t = t1;
-    double ft = t;
-    while (t < t2 + step) {
-      p = pointAt(t);
-      d = point.distanceToSquared(p);
-      if (d < mdist) {
-        mdist = d;
-        ft = t;
-      }
-      t += step;
-    }
-    return ProjectionResult()
-      ..point = pointAt(ft)
-      ..t = ft
-      ..distance = sqrt(mdist);
-  }
-}
-
-/// Result class for projection operation on beziers.
-class ProjectionResult {
-  Vector2 point;
-  double distance;
-  double t;
 }

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -725,6 +725,45 @@ abstract class Bezier {
 
     return lookUpTable;
   }
+  
+  double nearestTValue(Vector2 point, {List<Vector2> cachedPositionLookUpTable, double stepSize = 0.1}) {
+    final lookUpTable = cachedPositionLookUpTable ?? positionLookUpTable();
+
+    final index = indexOfNearestPoint(lookUpTable, point);
+
+    final maxIndex = lookUpTable.length - 1;
+    
+    if (index == 0) {
+      return 0.0;
+    } else if (index == maxIndex) {
+      return 1.0;
+    }
+
+    final divisor = maxIndex.toDouble();
+    final t1 = (index - 1) / divisor;
+    final t2 = (index + 1) / divisor;
+
+    final tIncrement = stepSize / divisor;
+    final maxT = t2 + tIncrement;
+
+    var t = t1;
+    var minSquaredDistance = double.maxFinite;
+    var nearestT = t1;
+
+    while (t < maxT) {
+      final pointOnCurve = pointAt(t);
+      final squaredDistance = point.distanceToSquared(pointOnCurve);
+
+      if (squaredDistance < minSquaredDistance) {
+        minSquaredDistance = squaredDistance;
+        nearestT = t;
+      }
+
+      t += tIncrement;
+    }
+
+    return nearestT;
+  }
 
   /// Returns a [ProjectionResult] object with the closest point to the closest off curve point 
   /// provided as the [point] parameter.

--- a/lib/src/bezier_tools.dart
+++ b/lib/src/bezier_tools.dart
@@ -378,6 +378,8 @@ List<Intersection> locateIntersectionsRecursively(
   return results;
 }
 
+/// Returns the index of the point in [points] that is closest (in terms of
+/// geometric distance) to [targetPoint].
 int indexOfNearestPoint(List<Vector2> points, Vector2 targetPoint) {
   var minSquaredDistance = double.maxFinite;
   var index;

--- a/lib/src/bezier_tools.dart
+++ b/lib/src/bezier_tools.dart
@@ -377,3 +377,20 @@ List<Intersection> locateIntersectionsRecursively(
 
   return results;
 }
+
+int indexOfNearestPoint(List<Vector2> points, Vector2 targetPoint) {
+  var minSquaredDistance = double.maxFinite;
+  var index;
+
+  final pointsCount = points.length;
+  for (var pointIndex = 0; pointIndex < pointsCount; pointIndex++) {
+    final point = points[pointIndex];
+    final squaredDistance = targetPoint.distanceToSquared(point);
+    if (squaredDistance < minSquaredDistance) {
+      minSquaredDistance = squaredDistance;
+      index = pointIndex;
+    }
+  }
+
+  return index;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bezier
-version: 1.0.3
+version: 1.1.0
 authors:
   - Aaron Barrett <aaron@aaronbarrett.com>
   - Isaac Barrett <ikebart9999@gmail.com>

--- a/test/testing_tools/testing_tools.dart
+++ b/test/testing_tools/testing_tools.dart
@@ -3,6 +3,7 @@ export "package:test/test.dart";
 export "package:vector_math/vector_math.dart";
 
 export "package:bezier/bezier.dart";
+export "package:bezier/src/bezier_tools.dart";
 
 export "matchers/close_to_double.dart";
 export "matchers/close_to_vector.dart";

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -13,6 +13,22 @@ void main() {
       expect(indexOfNearestPoint(points, new Vector2(80.0, -40.0)), equals(0));
     });
 
+    test("two points", () {
+      final points = [
+        new Vector2(-1.0, -1.0),
+        new Vector2(1.0, 1.0)
+      ];
+
+      expect(indexOfNearestPoint(points, new Vector2(-1.0, -1.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(1.0, 1.0)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(0.01, 0.01)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(-0.01, -0.01)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(500.0, 500.0)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(-10.0, -10.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(-10.0, 2.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(7.0, -200.0)), equals(0));
+    });
+
     test("distribution a", () {
       final points = [
         new Vector2(500.0, 10.0),

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -25,6 +25,12 @@ void main() {
       expect(indexOfNearestPoint(points, new Vector2(7.0, -200.0)), equals(0));
     });
 
+    test("equidistant solutions prefers earlier element", () {
+      final points = [new Vector2(-100.0, 0.0), new Vector2(100.0, 0.0)];
+
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(0));
+    });
+
     test("distribution a", () {
       final points = [
         new Vector2(500.0, 10.0),
@@ -145,6 +151,17 @@ void main() {
           closeToDouble(0.5866999999999));
       expect(curve.nearestTValue(new Vector2(0.0, 0.0), stepSize: 0.01),
           closeToDouble(0.586599999999));
+    });
+
+    test("quadratic, equidistant solutions prefers earlier t value", () {
+      final curve = new QuadraticBezier([
+        new Vector2(-1.0, 0.0),
+        new Vector2(0.0, 100.0),
+        new Vector2(1.0, 0.0),
+      ]);
+
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0)), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(0.0, 20.0)), closeToDouble(0.112));
     });
 
     test("cubic", () {

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -97,12 +97,63 @@ void main() {
       expect(curve.nearestTValue(new Vector2(91.0, 5.0)), equals(0.0));
       expect(curve.nearestTValue(new Vector2(-48.0, 48.0)), equals(1.0));
       expect(curve.nearestTValue(new Vector2(0.0, 0.0)), closeToDouble(0.586));
+      expect(curve.nearestTValue(new Vector2(35.0, -20.0)), closeToDouble(0.306));
+      expect(curve.nearestTValue(new Vector2(-45.0, 10.0)), closeToDouble(0.84));
       expect(curve.nearestTValue(curve.pointAt(0.034)), closeToDouble(0.034));
       expect(curve.nearestTValue(curve.pointAt(0.5)), closeToDouble(0.5));
       expect(curve.nearestTValue(curve.pointAt(0.666)), closeToDouble(0.666));
       expect(curve.nearestTValue(curve.pointAt(0.75)), closeToDouble(0.75));
       expect(curve.nearestTValue(curve.pointAt(0.77)), closeToDouble(0.77));
       expect(curve.nearestTValue(curve.pointAt(0.99)), closeToDouble(0.99));
+
+      final lookUpTable = curve.positionLookUpTable(intervalsCount: 300);
+
+      expect(curve.nearestTValue(new Vector2(91.0, 5.0), cachedPositionLookUpTable: lookUpTable), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(-48.0, 48.0), cachedPositionLookUpTable: lookUpTable), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.58666666666));
+      expect(curve.nearestTValue(new Vector2(24.0, 42.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.57233333333));
+
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.4), closeToDouble(0.58733333333));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.01), closeToDouble(0.5866999999999));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), stepSize: 0.01), closeToDouble(0.586599999999));
+    });
+
+    test("cubic", () {
+      final curve = new CubicBezier([
+        new Vector2(-100.0, -100.0),
+        new Vector2(-80.0, 50.0),
+        new Vector2(70.0, -50.0),
+        new Vector2(100.0, 100.0)
+      ]);
+
+      expect(curve.nearestTValue(new Vector2(-100.0, -100.0)), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(100.0, 100.0)), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(-80.0, 50.0)), closeToDouble(0.328));
+      expect(curve.nearestTValue(new Vector2(70.0, -50.0)), closeToDouble(0.666));
+      expect(curve.nearestTValue(new Vector2(-110.0, -110.0)), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(150.0, 190.0)), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0)), closeToDouble(0.514));
+      expect(curve.nearestTValue(new Vector2(17.0, -80.0)), closeToDouble(0.492));
+      expect(curve.nearestTValue(new Vector2(-55.0, -55.0)), closeToDouble(0.192));
+      expect(curve.nearestTValue(new Vector2(25.0, -90.0)), closeToDouble(0.51));
+      expect(curve.nearestTValue(curve.pointAt(0.01)), closeToDouble(0.01));
+      expect(curve.nearestTValue(curve.pointAt(0.11)), closeToDouble(0.11));
+      expect(curve.nearestTValue(curve.pointAt(0.34)), closeToDouble(0.34));
+      expect(curve.nearestTValue(curve.pointAt(0.5)), closeToDouble(0.5));
+      expect(curve.nearestTValue(curve.pointAt(0.55)), closeToDouble(0.55));
+      expect(curve.nearestTValue(curve.pointAt(0.83)), closeToDouble(0.83));
+      expect(curve.nearestTValue(curve.pointAt(0.99)), closeToDouble(0.99));
+
+      final lookUpTable = curve.positionLookUpTable(intervalsCount: 10);
+
+      expect(curve.nearestTValue(new Vector2(-110.0, -110.0), cachedPositionLookUpTable: lookUpTable), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(150.0, 190.0), cachedPositionLookUpTable: lookUpTable), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.51));
+      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.6));
+
+      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.4), closeToDouble(0.62));
+      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.01), closeToDouble(0.602));
+      expect(curve.nearestTValue(new Vector2(40.0, -40.0), stepSize: 0.01), closeToDouble(0.6024));
     });
   });
 }

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -1,0 +1,47 @@
+import "../testing_tools/testing_tools.dart";
+
+void main() {
+  group("indexOfNearestPoint", () {
+    test("one point", () {
+      final points = [
+        new Vector2(80.0, -40.0)
+      ];
+      
+      expect(indexOfNearestPoint(points, new Vector2(-30.0, -30.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(-7500.0, 48000.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(80.0, -40.0)), equals(0));
+    });
+
+    test("distribution a", () {
+      final points = [
+        new Vector2(500.0, 10.0),
+        new Vector2(0.0, 0.0),
+        new Vector2(-400.0, -20.0),
+        new Vector2(5.0, 5.0),
+        new Vector2(150.0, -350.0)
+      ];
+
+      expect(indexOfNearestPoint(points, new Vector2(10.0, 10.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(500.0, 10.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(495.0, 15.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(-1.0, 0.0)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(1.0, 0.5)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(-400.0, -20.0)), equals(2));
+      expect(indexOfNearestPoint(points, new Vector2(-5000.0, -20.0)), equals(2));
+      expect(indexOfNearestPoint(points, new Vector2(-400.0, -17.0)), equals(2));
+      expect(indexOfNearestPoint(points, new Vector2(5.0, 5.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(4.0, 4.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(10.0, 10.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(150.0, -350.0)), equals(4));
+      expect(indexOfNearestPoint(points, new Vector2(140.0, -340.0)), equals(4));
+      expect(indexOfNearestPoint(points, new Vector2(150.0, -9900.0)), equals(4));
+      expect(indexOfNearestPoint(points, new Vector2(90.0, 250.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 125.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(0.0, -125.0)), equals(1));
+      expect(indexOfNearestPoint(points, new Vector2(200.0, 0.0)), equals(3));
+      expect(indexOfNearestPoint(points, new Vector2(-100.0, 0.0)), equals(1));
+    });
+  });
+}

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -59,5 +59,27 @@ void main() {
       expect(indexOfNearestPoint(points, new Vector2(200.0, 0.0)), equals(3));
       expect(indexOfNearestPoint(points, new Vector2(-100.0, 0.0)), equals(1));
     });
+
+    test("from a look-up table", () {
+      final curve = new CubicBezier([
+        new Vector2(-100.0, 25.0),
+        new Vector2(-65.0, -110.0),
+        new Vector2(0.0, 20.0),
+        new Vector2(95.0, -100.0)
+      ]);
+
+      final points = curve.positionLookUpTable(intervalsCount: 200);
+
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(122));
+      expect(indexOfNearestPoint(points, new Vector2(800.0, 800.0)), equals(180));
+      expect(indexOfNearestPoint(points, new Vector2(-1000.0, 1000.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(0.0, 100.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(-100.0, 0.0)), equals(13));
+      expect(indexOfNearestPoint(points, new Vector2(100.0, 0.0)), equals(172));
+      expect(indexOfNearestPoint(points, new Vector2(-40.0, -10.0)), equals(81));
+      expect(indexOfNearestPoint(points, new Vector2(-100.0, 25.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(95.0, -100.0)), equals(200));
+      expect(indexOfNearestPoint(points, new Vector2(95.0, -190.0)), equals(200));
+    });
   });
 }

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -3,21 +3,17 @@ import "../testing_tools/testing_tools.dart";
 void main() {
   group("indexOfNearestPoint", () {
     test("one point", () {
-      final points = [
-        new Vector2(80.0, -40.0)
-      ];
-      
+      final points = [new Vector2(80.0, -40.0)];
+
       expect(indexOfNearestPoint(points, new Vector2(-30.0, -30.0)), equals(0));
-      expect(indexOfNearestPoint(points, new Vector2(-7500.0, 48000.0)), equals(0));
+      expect(indexOfNearestPoint(points, new Vector2(-7500.0, 48000.0)),
+          equals(0));
       expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(0));
       expect(indexOfNearestPoint(points, new Vector2(80.0, -40.0)), equals(0));
     });
 
     test("two points", () {
-      final points = [
-        new Vector2(-1.0, -1.0),
-        new Vector2(1.0, 1.0)
-      ];
+      final points = [new Vector2(-1.0, -1.0), new Vector2(1.0, 1.0)];
 
       expect(indexOfNearestPoint(points, new Vector2(-1.0, -1.0)), equals(0));
       expect(indexOfNearestPoint(points, new Vector2(1.0, 1.0)), equals(1));
@@ -44,15 +40,21 @@ void main() {
       expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(1));
       expect(indexOfNearestPoint(points, new Vector2(-1.0, 0.0)), equals(1));
       expect(indexOfNearestPoint(points, new Vector2(1.0, 0.5)), equals(1));
-      expect(indexOfNearestPoint(points, new Vector2(-400.0, -20.0)), equals(2));
-      expect(indexOfNearestPoint(points, new Vector2(-5000.0, -20.0)), equals(2));
-      expect(indexOfNearestPoint(points, new Vector2(-400.0, -17.0)), equals(2));
+      expect(
+          indexOfNearestPoint(points, new Vector2(-400.0, -20.0)), equals(2));
+      expect(
+          indexOfNearestPoint(points, new Vector2(-5000.0, -20.0)), equals(2));
+      expect(
+          indexOfNearestPoint(points, new Vector2(-400.0, -17.0)), equals(2));
       expect(indexOfNearestPoint(points, new Vector2(5.0, 5.0)), equals(3));
       expect(indexOfNearestPoint(points, new Vector2(4.0, 4.0)), equals(3));
       expect(indexOfNearestPoint(points, new Vector2(10.0, 10.0)), equals(3));
-      expect(indexOfNearestPoint(points, new Vector2(150.0, -350.0)), equals(4));
-      expect(indexOfNearestPoint(points, new Vector2(140.0, -340.0)), equals(4));
-      expect(indexOfNearestPoint(points, new Vector2(150.0, -9900.0)), equals(4));
+      expect(
+          indexOfNearestPoint(points, new Vector2(150.0, -350.0)), equals(4));
+      expect(
+          indexOfNearestPoint(points, new Vector2(140.0, -340.0)), equals(4));
+      expect(
+          indexOfNearestPoint(points, new Vector2(150.0, -9900.0)), equals(4));
       expect(indexOfNearestPoint(points, new Vector2(90.0, 250.0)), equals(3));
       expect(indexOfNearestPoint(points, new Vector2(0.0, 125.0)), equals(3));
       expect(indexOfNearestPoint(points, new Vector2(0.0, -125.0)), equals(1));
@@ -71,15 +73,20 @@ void main() {
       final points = curve.positionLookUpTable(intervalsCount: 200);
 
       expect(indexOfNearestPoint(points, new Vector2(0.0, 0.0)), equals(122));
-      expect(indexOfNearestPoint(points, new Vector2(800.0, 800.0)), equals(180));
-      expect(indexOfNearestPoint(points, new Vector2(-1000.0, 1000.0)), equals(0));
+      expect(
+          indexOfNearestPoint(points, new Vector2(800.0, 800.0)), equals(180));
+      expect(
+          indexOfNearestPoint(points, new Vector2(-1000.0, 1000.0)), equals(0));
       expect(indexOfNearestPoint(points, new Vector2(0.0, 100.0)), equals(0));
       expect(indexOfNearestPoint(points, new Vector2(-100.0, 0.0)), equals(13));
       expect(indexOfNearestPoint(points, new Vector2(100.0, 0.0)), equals(172));
-      expect(indexOfNearestPoint(points, new Vector2(-40.0, -10.0)), equals(81));
+      expect(
+          indexOfNearestPoint(points, new Vector2(-40.0, -10.0)), equals(81));
       expect(indexOfNearestPoint(points, new Vector2(-100.0, 25.0)), equals(0));
-      expect(indexOfNearestPoint(points, new Vector2(95.0, -100.0)), equals(200));
-      expect(indexOfNearestPoint(points, new Vector2(95.0, -190.0)), equals(200));
+      expect(
+          indexOfNearestPoint(points, new Vector2(95.0, -100.0)), equals(200));
+      expect(
+          indexOfNearestPoint(points, new Vector2(95.0, -190.0)), equals(200));
     });
   });
 
@@ -90,15 +97,18 @@ void main() {
         new Vector2(-10.0, -50.0),
         new Vector2(-45.0, 45.0)
       ]);
-      
+
       expect(curve.nearestTValue(new Vector2(90.0, 0.0)), equals(0.0));
       expect(curve.nearestTValue(new Vector2(-45.0, 45.0)), equals(1.0));
-      expect(curve.nearestTValue(new Vector2(-10.0, -50.0)), closeToDouble(0.518));
+      expect(
+          curve.nearestTValue(new Vector2(-10.0, -50.0)), closeToDouble(0.518));
       expect(curve.nearestTValue(new Vector2(91.0, 5.0)), equals(0.0));
       expect(curve.nearestTValue(new Vector2(-48.0, 48.0)), equals(1.0));
       expect(curve.nearestTValue(new Vector2(0.0, 0.0)), closeToDouble(0.586));
-      expect(curve.nearestTValue(new Vector2(35.0, -20.0)), closeToDouble(0.306));
-      expect(curve.nearestTValue(new Vector2(-45.0, 10.0)), closeToDouble(0.84));
+      expect(
+          curve.nearestTValue(new Vector2(35.0, -20.0)), closeToDouble(0.306));
+      expect(
+          curve.nearestTValue(new Vector2(-45.0, 10.0)), closeToDouble(0.84));
       expect(curve.nearestTValue(curve.pointAt(0.034)), closeToDouble(0.034));
       expect(curve.nearestTValue(curve.pointAt(0.5)), closeToDouble(0.5));
       expect(curve.nearestTValue(curve.pointAt(0.666)), closeToDouble(0.666));
@@ -108,14 +118,33 @@ void main() {
 
       final lookUpTable = curve.positionLookUpTable(intervalsCount: 300);
 
-      expect(curve.nearestTValue(new Vector2(91.0, 5.0), cachedPositionLookUpTable: lookUpTable), equals(0.0));
-      expect(curve.nearestTValue(new Vector2(-48.0, 48.0), cachedPositionLookUpTable: lookUpTable), equals(1.0));
-      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.58666666666));
-      expect(curve.nearestTValue(new Vector2(24.0, 42.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.57233333333));
+      expect(
+          curve.nearestTValue(new Vector2(91.0, 5.0),
+              cachedPositionLookUpTable: lookUpTable),
+          equals(0.0));
+      expect(
+          curve.nearestTValue(new Vector2(-48.0, 48.0),
+              cachedPositionLookUpTable: lookUpTable),
+          equals(1.0));
+      expect(
+          curve.nearestTValue(new Vector2(0.0, 0.0),
+              cachedPositionLookUpTable: lookUpTable),
+          closeToDouble(0.58666666666));
+      expect(
+          curve.nearestTValue(new Vector2(24.0, 42.0),
+              cachedPositionLookUpTable: lookUpTable),
+          closeToDouble(0.57233333333));
 
-      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.4), closeToDouble(0.58733333333));
-      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.01), closeToDouble(0.5866999999999));
-      expect(curve.nearestTValue(new Vector2(0.0, 0.0), stepSize: 0.01), closeToDouble(0.586599999999));
+      expect(
+          curve.nearestTValue(new Vector2(0.0, 0.0),
+              cachedPositionLookUpTable: lookUpTable, stepSize: 0.4),
+          closeToDouble(0.58733333333));
+      expect(
+          curve.nearestTValue(new Vector2(0.0, 0.0),
+              cachedPositionLookUpTable: lookUpTable, stepSize: 0.01),
+          closeToDouble(0.5866999999999));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0), stepSize: 0.01),
+          closeToDouble(0.586599999999));
     });
 
     test("cubic", () {
@@ -128,14 +157,19 @@ void main() {
 
       expect(curve.nearestTValue(new Vector2(-100.0, -100.0)), equals(0.0));
       expect(curve.nearestTValue(new Vector2(100.0, 100.0)), equals(1.0));
-      expect(curve.nearestTValue(new Vector2(-80.0, 50.0)), closeToDouble(0.328));
-      expect(curve.nearestTValue(new Vector2(70.0, -50.0)), closeToDouble(0.666));
+      expect(
+          curve.nearestTValue(new Vector2(-80.0, 50.0)), closeToDouble(0.328));
+      expect(
+          curve.nearestTValue(new Vector2(70.0, -50.0)), closeToDouble(0.666));
       expect(curve.nearestTValue(new Vector2(-110.0, -110.0)), equals(0.0));
       expect(curve.nearestTValue(new Vector2(150.0, 190.0)), equals(1.0));
       expect(curve.nearestTValue(new Vector2(0.0, 0.0)), closeToDouble(0.514));
-      expect(curve.nearestTValue(new Vector2(17.0, -80.0)), closeToDouble(0.492));
-      expect(curve.nearestTValue(new Vector2(-55.0, -55.0)), closeToDouble(0.192));
-      expect(curve.nearestTValue(new Vector2(25.0, -90.0)), closeToDouble(0.51));
+      expect(
+          curve.nearestTValue(new Vector2(17.0, -80.0)), closeToDouble(0.492));
+      expect(
+          curve.nearestTValue(new Vector2(-55.0, -55.0)), closeToDouble(0.192));
+      expect(
+          curve.nearestTValue(new Vector2(25.0, -90.0)), closeToDouble(0.51));
       expect(curve.nearestTValue(curve.pointAt(0.01)), closeToDouble(0.01));
       expect(curve.nearestTValue(curve.pointAt(0.11)), closeToDouble(0.11));
       expect(curve.nearestTValue(curve.pointAt(0.34)), closeToDouble(0.34));
@@ -146,14 +180,33 @@ void main() {
 
       final lookUpTable = curve.positionLookUpTable(intervalsCount: 10);
 
-      expect(curve.nearestTValue(new Vector2(-110.0, -110.0), cachedPositionLookUpTable: lookUpTable), equals(0.0));
-      expect(curve.nearestTValue(new Vector2(150.0, 190.0), cachedPositionLookUpTable: lookUpTable), equals(1.0));
-      expect(curve.nearestTValue(new Vector2(0.0, 0.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.51));
-      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable), closeToDouble(0.6));
+      expect(
+          curve.nearestTValue(new Vector2(-110.0, -110.0),
+              cachedPositionLookUpTable: lookUpTable),
+          equals(0.0));
+      expect(
+          curve.nearestTValue(new Vector2(150.0, 190.0),
+              cachedPositionLookUpTable: lookUpTable),
+          equals(1.0));
+      expect(
+          curve.nearestTValue(new Vector2(0.0, 0.0),
+              cachedPositionLookUpTable: lookUpTable),
+          closeToDouble(0.51));
+      expect(
+          curve.nearestTValue(new Vector2(40.0, -40.0),
+              cachedPositionLookUpTable: lookUpTable),
+          closeToDouble(0.6));
 
-      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.4), closeToDouble(0.62));
-      expect(curve.nearestTValue(new Vector2(40.0, -40.0), cachedPositionLookUpTable: lookUpTable, stepSize: 0.01), closeToDouble(0.602));
-      expect(curve.nearestTValue(new Vector2(40.0, -40.0), stepSize: 0.01), closeToDouble(0.6024));
+      expect(
+          curve.nearestTValue(new Vector2(40.0, -40.0),
+              cachedPositionLookUpTable: lookUpTable, stepSize: 0.4),
+          closeToDouble(0.62));
+      expect(
+          curve.nearestTValue(new Vector2(40.0, -40.0),
+              cachedPositionLookUpTable: lookUpTable, stepSize: 0.01),
+          closeToDouble(0.602));
+      expect(curve.nearestTValue(new Vector2(40.0, -40.0), stepSize: 0.01),
+          closeToDouble(0.6024));
     });
   });
 }

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -82,4 +82,27 @@ void main() {
       expect(indexOfNearestPoint(points, new Vector2(95.0, -190.0)), equals(200));
     });
   });
+
+  group("nearestTValue", () {
+    test("quadratic", () {
+      final curve = new QuadraticBezier([
+        new Vector2(90.0, 0.0),
+        new Vector2(-10.0, -50.0),
+        new Vector2(-45.0, 45.0)
+      ]);
+      
+      expect(curve.nearestTValue(new Vector2(90.0, 0.0)), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(-45.0, 45.0)), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(-10.0, -50.0)), closeToDouble(0.518));
+      expect(curve.nearestTValue(new Vector2(91.0, 5.0)), equals(0.0));
+      expect(curve.nearestTValue(new Vector2(-48.0, 48.0)), equals(1.0));
+      expect(curve.nearestTValue(new Vector2(0.0, 0.0)), closeToDouble(0.586));
+      expect(curve.nearestTValue(curve.pointAt(0.034)), closeToDouble(0.034));
+      expect(curve.nearestTValue(curve.pointAt(0.5)), closeToDouble(0.5));
+      expect(curve.nearestTValue(curve.pointAt(0.666)), closeToDouble(0.666));
+      expect(curve.nearestTValue(curve.pointAt(0.75)), closeToDouble(0.75));
+      expect(curve.nearestTValue(curve.pointAt(0.77)), closeToDouble(0.77));
+      expect(curve.nearestTValue(curve.pointAt(0.99)), closeToDouble(0.99));
+    });
+  });
 }


### PR DESCRIPTION
Bezier.js has a [`project`](http://pomax.github.io/bezierjs/#project) method, which I decided to leave out for `v1.0.0` of bezier.dart.  This PR adds the `nearestTValue` method, which has similar functionality.  Thanks to @luigi-rosso for getting the ball rolling here with https://github.com/aab29/bezier.dart/pull/8 .  🎳 🙌 

I also added `indexOfNearestPoint` in `bezier_tools`, which `nearestTValue` relies on, as well as unit tests for all the new functionality.  ✅ 

If all goes well, I'm going to release these features as `v1.1.0` on Pub!  🍻 