### PR TITLE
[FINAL] Using `isEmpty` and `isNotEmpty` instead of comparing to `length`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - bezier
 
+## v 1.1.1 - February 20 2019
+
+- Changed usages of `length == 0` and `length > 0` to `isEmpty` and `isNotEmpty`,
+  respectively, in accordance with hints provided by Pub
+
 ## v 1.1.0 - January 30 2019
 
 - Added `nearestTValue` method to `Bezier` class, based on work by @luigi-rosso -- Thanks!

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -593,13 +593,13 @@ abstract class Bezier {
     var firstIntersection = intersectionsToFilter[0];
     var sublist = intersectionsToFilter.sublist(1);
     final filteredList = <Intersection>[firstIntersection];
-    while (sublist.length > 0) {
+    while (sublist.isNotEmpty) {
       sublist.removeWhere((intersection) {
         return intersection.isWithinTValueOf(
             firstIntersection, minTValueDifference);
       });
 
-      if (sublist.length > 0) {
+      if (sublist.isNotEmpty) {
         firstIntersection = sublist[0];
         sublist = sublist.sublist(1);
         filteredList.add(firstIntersection);

--- a/lib/src/bezier_tools.dart
+++ b/lib/src/bezier_tools.dart
@@ -364,7 +364,7 @@ List<Intersection> locateIntersectionsRecursively(
       indicesOfOverlappingSegmentPairs(pairLeftSides, pairRightSides);
 
   final results = <Intersection>[];
-  if (overlappingPairIndices.length == 0) {
+  if (overlappingPairIndices.isEmpty) {
     return results;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bezier
-version: 1.1.0
+version: 1.1.1
 authors:
   - Aaron Barrett <aaron@aaronbarrett.com>
   - Isaac Barrett <ikebart9999@gmail.com>


### PR DESCRIPTION
Changing usages of `length == 0` and `length > 0` to `isEmpty` and `isNotEmpty`, respectively, in accordance with hints provided by Pub. 🍻  Bumping version numbers to `1.1.1`.  🆙 