### PR TITLE
[FINAL] Line segment intersections bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - bezier
 
+## v 1.1.2 - May 19 2019
+
+- Fixed certain cases, reported by @fidlip (Thank you!), where `intersectionsWithLineSegment` failed to find intersections
+- Added `pointIntersectsBoundingBoxApproximately` in `bezier_tools` to support `intersectionsWithLineSegment`
+- Added more unit tests for `intersectionsWithLineSegment`, based on cases reported by @fidlip
+
 ## v 1.1.1 - February 20 2019
 
 - Changed usages of `length == 0` and `length > 0` to `isEmpty` and `isNotEmpty`,

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -699,7 +699,7 @@ abstract class Bezier {
     final roots = rootsAlongLine(points, lineStartPoint, lineEndPoint);
     roots.retainWhere((t) {
       final p = pointAt(t);
-      return boundingBox.intersectsWithVector2(p);
+      return pointIntersectsBoundingBoxApproximately(p, boundingBox);
     });
     final rootsSet = new Set<double>.from(roots);
     final uniqueRoots = rootsSet.toList();

--- a/lib/src/bezier_tools.dart
+++ b/lib/src/bezier_tools.dart
@@ -80,6 +80,24 @@ const legendrePolynomialWeights = [
 bool isApproximately(double a, double b, {double precision = 0.000001}) =>
     ((a - b).abs() <= precision);
 
+/// True if [point] intersects [boundingBox], or is within [precision] of the border.
+bool pointIntersectsBoundingBoxApproximately(Vector2 point, Aabb2 boundingBox,
+    {double precision = 0.0001}) {
+  final x = point.x;
+  final y = point.y;
+  final min = boundingBox.min;
+  final max = boundingBox.max;
+
+  final xIsInBoundingBox = ((min.x <= x) && (x <= max.x)) ||
+      isApproximately(x, min.x, precision: precision) ||
+      isApproximately(x, max.x, precision: precision);
+  final yIsInBoundingBox = ((min.y <= y) && (y <= max.y)) ||
+      isApproximately(y, min.y, precision: precision) ||
+      isApproximately(y, max.y, precision: precision);
+
+  return xIsInBoundingBox && yIsInBoundingBox;
+}
+
 /// Returns the cube root of [realNumber] from within the real numbers such that
 /// the result raised to the third power equals [realNumber].
 double principalCubeRoot(double realNumber) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bezier
-version: 1.1.1
+version: 1.1.2
 authors:
   - Aaron Barrett <aaron@aaronbarrett.com>
   - Isaac Barrett <ikebart9999@gmail.com>

--- a/test/unit_tests/bezier_intersection_methods_test.dart
+++ b/test/unit_tests/bezier_intersection_methods_test.dart
@@ -613,5 +613,88 @@ void main() {
       final result = curve.intersectionsWithLineSegment(p1, p2);
       expect(result, hasLength(1));
     });
+
+    test(
+        "cubic intersectionsWithLineSegment, y axis through typical curve, one intersection",
+        () {
+      final curve = new CubicBezier([
+        Vector2(-214.5, 80.0),
+        Vector2(-52.0, 80.0),
+        Vector2(52.0, 530.0),
+        Vector2(214.5, 530.0)
+      ]);
+      final p1 = new Vector2(0.0, 0.0);
+      final p2 = new Vector2(0.0, 1080.0);
+
+      final result = curve.intersectionsWithLineSegment(p1, p2);
+      expect(result, hasLength(1));
+    });
+
+    test(
+        "cubic intersectionsWithLineSegment, y axis through typical curve, translated to the right, one intersection",
+        () {
+      final offset = 429.0;
+      final curve = new CubicBezier([
+        Vector2(-214.5 + offset, 80.0),
+        Vector2(-52.0 + offset, 80.0),
+        Vector2(52.0 + offset, 530.0),
+        Vector2(214.5 + offset, 530.0)
+      ]);
+      final p1 = new Vector2(0.0 + offset, 0.0);
+      final p2 = new Vector2(0.0 + offset, 1080.0);
+
+      final result = curve.intersectionsWithLineSegment(p1, p2);
+      expect(result, hasLength(1));
+    });
+
+    test(
+        "cubic intersectionsWithLineSegment, horizontal line through typical curve",
+        () {
+      final curve = new CubicBezier([
+        Vector2(214.5, 630.0),
+        Vector2(308.25, 630.0),
+        Vector2(368.625, 492.5),
+        Vector2(429.0, 355.0)
+      ]);
+      final p1 = new Vector2(0.0, 580.0);
+      final p2 = new Vector2(430.0, 580.0);
+
+      final result = curve.intersectionsWithLineSegment(p1, p2);
+      expect(result, hasLength(1));
+    });
+
+    test(
+        "cubic intersectionsWithLineSegment, horizontal line through typical curve, translated up",
+        () {
+      final offset = 6.0;
+      final curve = new CubicBezier([
+        Vector2(214.5, 630.0 + offset),
+        Vector2(308.25, 630.0 + offset),
+        Vector2(368.625, 492.5 + offset),
+        Vector2(429.0, 355.0 + offset)
+      ]);
+      final p1 = new Vector2(0.0, 580.0 + offset);
+      final p2 = new Vector2(430.0, 580.0 + offset);
+
+      final result = curve.intersectionsWithLineSegment(p1, p2);
+      expect(result, hasLength(1));
+    });
+
+    test(
+        "cubic intersectionsWithLineSegment, horizontal line through typical curve, translated down",
+        () {
+      final offset = -6.0;
+      final curve = new CubicBezier([
+        Vector2(214.5, 630.0 + offset),
+        Vector2(308.25, 630.0 + offset),
+        Vector2(368.625, 492.5 + offset),
+        Vector2(429.0, 355.0 + offset)
+      ]);
+      final p1 = new Vector2(0.0, 580.0 + offset);
+      final p2 = new Vector2(430.0, 580.0 + offset);
+
+      final result = curve.intersectionsWithLineSegment(p1, p2);
+      expect(result, hasLength(1));
+    });
   });
 }


### PR DESCRIPTION
Added automated test cases to cover the instances reported by @fidlip , where `intersectionsWithLineSegment` failed to detect intersections. 📊  After examining the steps followed by Bezier.js, I realized that bezier.dart was missing an important detail. 🔍  I changed `intersectionsWithLineSegment` to rely on `pointIntersectsBoundingBoxApproximately`, and the failing test cases now pass.  ✅ 

I also bumped the version number to `1.1.2`.  🆙 