### PR TITLE
[FINAL] Switch to single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - bezier
 
+## v 1.1.5 - December 21 2019
+
+- Replaced all usages of double quotes with single quotes in order to conform to the latest style recommendations.
+- Fixed one instance (in `quadratic_bezier.dart`) where we used a `List()` constructor instead of the `[]` literal. 
+
 ## v 1.1.4 - December 10 2019
 
 - Just updating this changelog file, since I forgot to in 1.1.3

--- a/lib/bezier.dart
+++ b/lib/bezier.dart
@@ -9,9 +9,9 @@
 /// [Bezier.js](https://pomax.github.io/bezierjs/).
 library bezier;
 
-export "src/bezier.dart";
-export "src/bezier_slice.dart";
-export "src/cubic_bezier.dart";
-export "src/even_spacer.dart";
-export "src/intersection.dart";
-export "src/quadratic_bezier.dart";
+export 'src/bezier.dart';
+export 'src/bezier_slice.dart';
+export 'src/cubic_bezier.dart';
+export 'src/even_spacer.dart';
+export 'src/intersection.dart';
+export 'src/quadratic_bezier.dart';

--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -1,10 +1,10 @@
-import "dart:math";
+import 'dart:math';
 
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
-import "bezier_tools.dart";
+import 'bezier_tools.dart';
 
 /// Abstract base class of Bézier curves.
 abstract class Bezier {
@@ -30,7 +30,7 @@ abstract class Bezier {
     } else if (curvePoints.length == 4) {
       return CubicBezier(curvePoints);
     } else {
-      throw UnsupportedError("Unsupported number of curve points");
+      throw UnsupportedError('Unsupported number of curve points');
     }
   }
 
@@ -63,7 +63,7 @@ abstract class Bezier {
     } else if (derivativeOrder > this.order) {
       return [];
     } else if (derivativeOrder < 1) {
-      throw ArgumentError("invalid order for derivatives");
+      throw ArgumentError('invalid order for derivatives');
     }
 
     final pointsToProcess =
@@ -204,7 +204,7 @@ abstract class Bezier {
   /// left of parameter value [t].
   Bezier leftSubcurveAt(double t) {
     if (t <= 0.0) {
-      throw ArgumentError("Cannot split curve left of start point");
+      throw ArgumentError('Cannot split curve left of start point');
     }
 
     t = min(t, 1.0);
@@ -217,7 +217,7 @@ abstract class Bezier {
       return CubicBezier(
           [hullPoints[0], hullPoints[4], hullPoints[7], hullPoints[9]]);
     } else {
-      throw UnsupportedError("Unsupported curve order");
+      throw UnsupportedError('Unsupported curve order');
     }
   }
 
@@ -225,7 +225,7 @@ abstract class Bezier {
   /// right of parameter value [t].
   Bezier rightSubcurveAt(double t) {
     if (t >= 1.0) {
-      throw ArgumentError("Cannot split curve right of end point");
+      throw ArgumentError('Cannot split curve right of end point');
     }
 
     t = max(t, 0.0);
@@ -237,7 +237,7 @@ abstract class Bezier {
       return CubicBezier(
           [hullPoints[9], hullPoints[8], hullPoints[6], hullPoints[3]]);
     } else {
-      throw UnsupportedError("Unsupported curve order");
+      throw UnsupportedError('Unsupported curve order');
     }
   }
 

--- a/lib/src/bezier_slice.dart
+++ b/lib/src/bezier_slice.dart
@@ -1,4 +1,4 @@
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
 /// Class wrapping a [Bezier] instance and the parameter values for the
 /// start and end points of the instance in a parent [Bezier] instance.
@@ -15,5 +15,5 @@ class BezierSlice {
   BezierSlice(this.subcurve, this.t1, this.t2);
 
   @override
-  String toString() => "BDBezierSlice($subcurve, t1: $t1, t2: $t2)";
+  String toString() => 'BDBezierSlice($subcurve, t1: $t1, t2: $t2)';
 }

--- a/lib/src/bezier_tools.dart
+++ b/lib/src/bezier_tools.dart
@@ -1,8 +1,8 @@
-import "dart:math";
+import 'dart:math';
 
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
 /// The roots of the Legendre polynomial for n == 30.
 ///
@@ -275,7 +275,7 @@ List<double> polynomialRoots(List<double> polynomial) {
     return <double>[];
   } else {
     throw UnsupportedError(
-        "Fourth and higher order polynomials not supported.");
+        'Fourth and higher order polynomials not supported.');
   }
 }
 

--- a/lib/src/cubic_bezier.dart
+++ b/lib/src/cubic_bezier.dart
@@ -1,6 +1,6 @@
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
 /// Concrete class of cubic Bézier curves.
 class CubicBezier extends Bezier {
@@ -9,7 +9,7 @@ class CubicBezier extends Bezier {
   /// be its control points, and the fourth point will be its end point.
   CubicBezier(List<Vector2> points) : super(points) {
     if (points.length != 4) {
-      throw ArgumentError("Cubic Bézier curves require exactly four points");
+      throw ArgumentError('Cubic Bézier curves require exactly four points');
     }
   }
 
@@ -55,5 +55,5 @@ class CubicBezier extends Bezier {
 
   @override
   String toString() =>
-      "BDCubicBezier([${points[0]}, ${points[1]}, ${points[2]}, ${points[3]}])";
+      'BDCubicBezier([${points[0]}, ${points[1]}, ${points[2]}, ${points[3]}])';
 }

--- a/lib/src/even_spacer.dart
+++ b/lib/src/even_spacer.dart
@@ -1,8 +1,8 @@
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
-import "bezier_tools.dart";
+import 'bezier_tools.dart';
 
 /// Class for calculating parameter values of points in a [Bezier] evenly spaced
 /// along its arc length.
@@ -18,7 +18,7 @@ class EvenSpacer {
   /// calculated at evenly spaced parameter values within a [Bezier].
   EvenSpacer(this.curveLookUpTable) {
     if (curveLookUpTable.length < 2) {
-      throw ArgumentError("look up table requires at least two entries");
+      throw ArgumentError('look up table requires at least two entries');
     }
 
     for (var index = 1; index < curveLookUpTable.length; index++) {

--- a/lib/src/intersection.dart
+++ b/lib/src/intersection.dart
@@ -1,4 +1,4 @@
-import "dart:math";
+import 'dart:math';
 
 /// Describes intersections between two Bézier curves.
 class Intersection {
@@ -25,5 +25,5 @@ class Intersection {
       (maxTValueDifference(other) <= tValueDifference);
 
   @override
-  String toString() => "BDIntersection($t1, $t2)";
+  String toString() => 'BDIntersection($t1, $t2)';
 }

--- a/lib/src/quadratic_bezier.dart
+++ b/lib/src/quadratic_bezier.dart
@@ -1,6 +1,6 @@
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "package:bezier/bezier.dart";
+import 'package:bezier/bezier.dart';
 
 /// Concrete class of quadratic Bézier curves.
 class QuadraticBezier extends Bezier {
@@ -10,7 +10,7 @@ class QuadraticBezier extends Bezier {
   QuadraticBezier(List<Vector2> points) : super(points) {
     if (points.length != 3) {
       throw ArgumentError(
-          "Quadratic Bézier curves require exactly three points");
+          'Quadratic Bézier curves require exactly three points');
     }
   }
 
@@ -71,5 +71,5 @@ class QuadraticBezier extends Bezier {
 
   @override
   String toString() =>
-      "BDQuadraticBezier([${points[0]}, ${points[1]}, ${points[2]}])";
+      'BDQuadraticBezier([${points[0]}, ${points[1]}, ${points[2]}])';
 }

--- a/lib/src/quadratic_bezier.dart
+++ b/lib/src/quadratic_bezier.dart
@@ -49,7 +49,7 @@ class QuadraticBezier extends Bezier {
   /// and control points positioned so it produces identical points along the
   /// curve as [this].
   CubicBezier toCubicBezier() {
-    final cubicCurvePoints = List<Vector2>();
+    final cubicCurvePoints = <Vector2>[];
     cubicCurvePoints.add(startPoint);
 
     final pointsCount = points.length;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bezier
-version: 1.1.4
+version: 1.1.5
 authors:
   - Aaron Barrett <aaron@aaronbarrett.com>
   - Isaac Barrett <ikebart9999@gmail.com>

--- a/test/testing_tools/matchers/close_to_double.dart
+++ b/test/testing_tools/matchers/close_to_double.dart
@@ -1,4 +1,4 @@
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 const defaultDelta = 0.00001;
 

--- a/test/testing_tools/matchers/close_to_vector.dart
+++ b/test/testing_tools/matchers/close_to_vector.dart
@@ -1,8 +1,8 @@
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "close_to_double.dart";
+import 'close_to_double.dart';
 
 class CloseToVectorMatcher extends Matcher {
   Vector vector;

--- a/test/testing_tools/matchers/close_to_vector_list.dart
+++ b/test/testing_tools/matchers/close_to_vector_list.dart
@@ -1,9 +1,9 @@
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "package:vector_math/vector_math.dart";
+import 'package:vector_math/vector_math.dart';
 
-import "close_to_double.dart";
-import "close_to_vector.dart";
+import 'close_to_double.dart';
+import 'close_to_vector.dart';
 
 class CloseToVectorListMatcher extends Matcher {
   List<Vector> vectors;

--- a/test/testing_tools/testing_tools.dart
+++ b/test/testing_tools/testing_tools.dart
@@ -1,10 +1,10 @@
-export "package:test/test.dart";
+export 'package:test/test.dart';
 
-export "package:vector_math/vector_math.dart";
+export 'package:vector_math/vector_math.dart';
 
-export "package:bezier/bezier.dart";
-export "package:bezier/src/bezier_tools.dart";
+export 'package:bezier/bezier.dart';
+export 'package:bezier/src/bezier_tools.dart';
 
-export "matchers/close_to_double.dart";
-export "matchers/close_to_vector.dart";
-export "matchers/close_to_vector_list.dart";
+export 'matchers/close_to_double.dart';
+export 'matchers/close_to_vector.dart';
+export 'matchers/close_to_vector_list.dart';

--- a/test/unit_tests/bezier_bounding_box_methods_test.dart
+++ b/test/unit_tests/bezier_bounding_box_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("boundingBox", () {
-    test("cubic boundingBox", () {
+  group('boundingBox', () {
+    test('cubic boundingBox', () {
       final points = [
         Vector2(10.0, -10.0),
         Vector2(70.0, 95.0),
@@ -19,7 +19,7 @@ void main() {
       expect(box.max, closeToVector(Vector2(30.47231674194336, 80.0)));
     });
 
-    test("quadratic boundingBox", () {
+    test('quadratic boundingBox', () {
       final points = [
         Vector2(65.0, 95.0),
         Vector2(-25.0, -20.0),
@@ -38,8 +38,8 @@ void main() {
     });
   });
 
-  group("overlaps", () {
-    test("cubic overlaps with other cubic curve", () {
+  group('overlaps', () {
+    test('cubic overlaps with other cubic curve', () {
       final curveA = CubicBezier([
         Vector2(-10.0, -10.0),
         Vector2(-70.0, -95.0),
@@ -71,7 +71,7 @@ void main() {
       expect(curveC.overlaps(curveB), isTrue);
     });
 
-    test("quadratic overlaps with other quadratic curve", () {
+    test('quadratic overlaps with other quadratic curve', () {
       final curveA = QuadraticBezier([
         Vector2(-70.0, -95.0),
         Vector2(-25.0, -20.0),
@@ -94,7 +94,7 @@ void main() {
       expect(curveC.overlaps(curveB), isTrue);
     });
 
-    test("quadratic overlaps with quadratic and cubic curves", () {
+    test('quadratic overlaps with quadratic and cubic curves', () {
       final curveA = QuadraticBezier(
           [Vector2(-70.0, -95.0), Vector2(-25.0, -20.0), Vector2(-15.0, 5.0)]);
 
@@ -119,8 +119,8 @@ void main() {
     });
   });
 
-  group("extremaOnX", () {
-    test("cubic extremaOnX", () {
+  group('extremaOnX', () {
+    test('cubic extremaOnX', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -137,7 +137,7 @@ void main() {
       expect(result[1], closeToDouble(0.75));
     });
 
-    test("quadratic extremaOnX", () {
+    test('quadratic extremaOnX', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -153,8 +153,8 @@ void main() {
     });
   });
 
-  group("extremaOnY", () {
-    test("cubic extremaOnY", () {
+  group('extremaOnY', () {
+    test('cubic extremaOnY', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -172,7 +172,7 @@ void main() {
       expect(result[2], closeToDouble(0.6200436558467092));
     });
 
-    test("quadratic extremaOnY", () {
+    test('quadratic extremaOnY', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -188,8 +188,8 @@ void main() {
     });
   });
 
-  group("extrema", () {
-    test("cubic extrema", () {
+  group('extrema', () {
+    test('cubic extrema', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -209,7 +209,7 @@ void main() {
       expect(result[4], closeToDouble(0.75));
     });
 
-    test("quadratic extrema", () {
+    test('quadratic extrema', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -225,7 +225,7 @@ void main() {
       expect(result[1], closeToDouble(0.5714285714285714));
     });
 
-    test("quadratic extrema, degenerate curve", () {
+    test('quadratic extrema, degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(50.0, 0.0)]);
 

--- a/test/unit_tests/bezier_constructor_test.dart
+++ b/test/unit_tests/bezier_constructor_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("unnamed constructor", () {
-    test("quadratic constructor", () {
+  group('unnamed constructor', () {
+    test('quadratic constructor', () {
       final points = [
         Vector2(40.0, 40.0),
         Vector2(30.0, 10.0),
@@ -15,7 +15,7 @@ void main() {
       expect(curve.points, hasLength(3));
     });
 
-    test("cubic constructor", () {
+    test('cubic constructor', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -30,8 +30,8 @@ void main() {
     });
   });
 
-  group("fromPoints constructor", () {
-    test("fromPoints, three entries", () {
+  group('fromPoints constructor', () {
+    test('fromPoints, three entries', () {
       final points = <Vector2>[
         Vector2(0.0, 0.0),
         Vector2(250.0, -50.0),
@@ -44,7 +44,7 @@ void main() {
       expect(curve.points, hasLength(3));
     });
 
-    test("fromPoints, four entries", () {
+    test('fromPoints, four entries', () {
       final points = <Vector2>[
         Vector2(0.0, 0.0),
         Vector2(170.0, 90.0),
@@ -58,7 +58,7 @@ void main() {
       expect(curve.points, hasLength(4));
     });
 
-    test("fromPoints, error thrown with five entries", () {
+    test('fromPoints, error thrown with five entries', () {
       final points = <Vector2>[
         Vector2(0.0, 0.0),
         Vector2(170.0, 90.0),

--- a/test/unit_tests/bezier_getter_methods_test.dart
+++ b/test/unit_tests/bezier_getter_methods_test.dart
@@ -1,14 +1,14 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("startPoint", () {
-    test("quadratic startPoint", () {
+  group('startPoint', () {
+    test('quadratic startPoint', () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
       expect(curve.startPoint, closeToVector(Vector2(10.0, 10.0)));
     });
 
-    test("cubic startPoint", () {
+    test('cubic startPoint', () {
       final curve = CubicBezier([
         Vector2(90.0, 80.0),
         Vector2(50.0, 10.0),
@@ -19,14 +19,14 @@ void main() {
     });
   });
 
-  group("endPoint", () {
-    test("quadratic endPoint", () {
+  group('endPoint', () {
+    test('quadratic endPoint', () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
       expect(curve.endPoint, closeToVector(Vector2(15.0, 80.0)));
     });
 
-    test("cubic endPoint", () {
+    test('cubic endPoint', () {
       final curve = CubicBezier([
         Vector2(90.0, 80.0),
         Vector2(50.0, 10.0),
@@ -37,8 +37,8 @@ void main() {
     });
   });
 
-  group("derivativePoints", () {
-    test("quadratic derivativePoints", () {
+  group('derivativePoints', () {
+    test('quadratic derivativePoints', () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
 
@@ -54,7 +54,7 @@ void main() {
       expect(curve.derivativePoints(derivativeOrder: 3), isEmpty);
     });
 
-    test("cubic derivativePoints", () {
+    test('cubic derivativePoints', () {
       final points = [
         Vector2(90.0, 80.0),
         Vector2(50.0, 10.0),
@@ -80,7 +80,7 @@ void main() {
       expect(dpoints3[0], closeToVector(Vector2(210.0, -1650.0)));
     });
 
-    test("quadratic derivativePoints, second test", () {
+    test('quadratic derivativePoints, second test', () {
       final points = [
         Vector2(40.0, 40.0),
         Vector2(30.0, 10.0),
@@ -99,8 +99,8 @@ void main() {
     });
   });
 
-  group("isClockwise", () {
-    test("quadratic isClockwise", () {
+  group('isClockwise', () {
+    test('quadratic isClockwise', () {
       final clockwiseCurve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -117,7 +117,7 @@ void main() {
       expect(linearCurve.isClockwise, isFalse);
     });
 
-    test("cubic isClockwise", () {
+    test('cubic isClockwise', () {
       final clockwiseCurve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(100.0, 250.0),
@@ -146,7 +146,7 @@ void main() {
       expect(linearCurve.isClockwise, isFalse);
     });
 
-    test("cubic isClockwise, clockwise curve", () {
+    test('cubic isClockwise, clockwise curve', () {
       final points = [
         Vector2(50.0, 10.0),
         Vector2(40.0, 85.0),
@@ -157,7 +157,7 @@ void main() {
       expect(curve.isClockwise, isTrue);
     });
 
-    test("quadratic isClockwise, clockwise curve", () {
+    test('quadratic isClockwise, clockwise curve', () {
       final points = [
         Vector2(-40.0, -40.0),
         Vector2(30.0, 10.0),
@@ -167,7 +167,7 @@ void main() {
       expect(curve.isClockwise, isTrue);
     });
 
-    test("cubic isClockwise, counter-clockwise curve", () {
+    test('cubic isClockwise, counter-clockwise curve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -178,7 +178,7 @@ void main() {
       expect(curve.isClockwise, isFalse);
     });
 
-    test("quadratic isClockwise, counter-clockwise curve", () {
+    test('quadratic isClockwise, counter-clockwise curve', () {
       final points = [
         Vector2(55.0, 25.0),
         Vector2(40.0, 40.0),
@@ -189,7 +189,7 @@ void main() {
     });
 
     test(
-        "quadratic isClockwise, diagonal degenerate curve with control point beyond end point",
+        'quadratic isClockwise, diagonal degenerate curve with control point beyond end point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 100.0), Vector2(20.0, 20.0)]);
@@ -197,7 +197,7 @@ void main() {
     });
 
     test(
-        "quadratic isClockwise, diagonal degenerate curve with control point before start point",
+        'quadratic isClockwise, diagonal degenerate curve with control point before start point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(-100.0, -100.0), Vector2(20.0, 20.0)]);
@@ -205,7 +205,7 @@ void main() {
     });
 
     test(
-        "quadratic isClockwise, horizontal degenerate curve with control point beyond end point",
+        'quadratic isClockwise, horizontal degenerate curve with control point beyond end point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(20.0, 0.0)]);
@@ -213,7 +213,7 @@ void main() {
     });
 
     test(
-        "quadratic isClockwise, horizontal degenerate curve with control point before start point",
+        'quadratic isClockwise, horizontal degenerate curve with control point before start point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(-100.0, 0.0), Vector2(20.0, 0.0)]);
@@ -221,8 +221,8 @@ void main() {
     });
   });
 
-  group("isLinear", () {
-    test("quadratic isLinear", () {
+  group('isLinear', () {
+    test('quadratic isLinear', () {
       final linearCurve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(20.0, 20.0), Vector2(100.0, 100.0)]);
 
@@ -234,7 +234,7 @@ void main() {
       expect(nonlinearCurve.isLinear, isFalse);
     });
 
-    test("cubic isLinear", () {
+    test('cubic isLinear', () {
       final linearCurve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(33.0, 33.0),
@@ -254,7 +254,7 @@ void main() {
       expect(nonLinearCurve.isLinear, isFalse);
     });
 
-    test("cubic isLinear, linear curve", () {
+    test('cubic isLinear, linear curve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(20.0, 20.0),
@@ -265,7 +265,7 @@ void main() {
       expect(curve.isLinear, isTrue);
     });
 
-    test("quadratic isLinear, linear curve", () {
+    test('quadratic isLinear, linear curve', () {
       final points = [
         Vector2(-10.0, -10.0),
         Vector2(20.0, 20.0),
@@ -275,7 +275,7 @@ void main() {
       expect(curve.isLinear, isTrue);
     });
 
-    test("cubic isLinear, non-linear curve", () {
+    test('cubic isLinear, non-linear curve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(20.0, 20.001),
@@ -286,7 +286,7 @@ void main() {
       expect(curve.isLinear, isFalse);
     });
 
-    test("quadratic isLinear, not linear curve", () {
+    test('quadratic isLinear, not linear curve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(20.0, 20.0),
@@ -296,19 +296,19 @@ void main() {
       expect(curve.isLinear, isFalse);
     });
 
-    test("quadratic isLinear, diagonal degenerate curve", () {
+    test('quadratic isLinear, diagonal degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(-100.0, -100.0), Vector2(20.0, 20.0)]);
       expect(curve.isLinear, isTrue);
     });
 
-    test("quadratic isLinear, horizontal degenerate curve", () {
+    test('quadratic isLinear, horizontal degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(-100.0, 0.0), Vector2(20.0, 0.0)]);
       expect(curve.isLinear, isTrue);
     });
 
-    test("cubic isLinear, diagonal degenerate curve", () {
+    test('cubic isLinear, diagonal degenerate curve', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(-100.0, -30.0),
@@ -318,7 +318,7 @@ void main() {
       expect(curve.isLinear, isTrue);
     });
 
-    test("cubic isLinear, horizontal degenerate curve", () {
+    test('cubic isLinear, horizontal degenerate curve', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(-100.0, 0.0),
@@ -329,8 +329,8 @@ void main() {
     });
   });
 
-  group("length", () {
-    test("cubic length", () {
+  group('length', () {
+    test('cubic length', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -341,7 +341,7 @@ void main() {
       expect(curve.length, closeToDouble(95.80310376637526));
     });
 
-    test("quadratic length", () {
+    test('quadratic length', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -351,7 +351,7 @@ void main() {
       expect(curve.length, closeToDouble(102.64876949628173));
     });
 
-    test("cubic length, linear curve", () {
+    test('cubic length, linear curve', () {
       final points = [
         Vector2(0.0, 0.0),
         Vector2(-70.0, -70.0),
@@ -362,7 +362,7 @@ void main() {
       expect(curve.length, closeToDouble(141.42135469034142));
     });
 
-    test("quadratic length, linear curve", () {
+    test('quadratic length, linear curve', () {
       final points = [
         Vector2(-70.0, -70.0),
         Vector2(-80.0, -80.0),
@@ -372,13 +372,13 @@ void main() {
       expect(curve.length, closeToDouble(42.426406480714064));
     });
 
-    test("quadratic length, degenerate curve", () {
+    test('quadratic length, degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(50.0, 0.0)]);
       expect(curve.length, closeToDouble(83.32994626641911));
     });
 
-    test("cubic length, degenerate curve", () {
+    test('cubic length, degenerate curve', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(-100.0, 0.0),
@@ -389,8 +389,8 @@ void main() {
     });
   });
 
-  group("isSimple", () {
-    test("cubic isSimple, simple curve", () {
+  group('isSimple', () {
+    test('cubic isSimple, simple curve', () {
       final points = [
         Vector2(100.0, 100.0),
         Vector2(90.0, 80.0),
@@ -402,7 +402,7 @@ void main() {
       expect(curve.isSimple, isTrue);
     });
 
-    test("cubic isSimple, non-simple curve", () {
+    test('cubic isSimple, non-simple curve', () {
       final points = [
         Vector2(105.0, 70.0),
         Vector2(50.0, 50.0),
@@ -414,7 +414,7 @@ void main() {
       expect(curve.isSimple, isFalse);
     });
 
-    test("quadratic isSimple, simple curve", () {
+    test('quadratic isSimple, simple curve', () {
       final points = [
         Vector2(20.0, 20.0),
         Vector2(60.0, 60.0),
@@ -425,7 +425,7 @@ void main() {
       expect(curve.isSimple, isTrue);
     });
 
-    test("quadratic isSimple, non-simple curve", () {
+    test('quadratic isSimple, non-simple curve', () {
       final points = [
         Vector2(20.0, 60.0),
         Vector2(100.0, 20.0),
@@ -437,7 +437,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, non-simple curve with near-parallel endpoint normal vectors",
+        'cubic isSimple, non-simple curve with near-parallel endpoint normal vectors',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -449,21 +449,21 @@ void main() {
       expect(curve.isSimple, isFalse);
     });
 
-    test("quadratic isSimple, simple curve border case", () {
+    test('quadratic isSimple, simple curve border case', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 28.86), Vector2(100.0, 0.0)]);
 
       expect(curve.isSimple, isTrue);
     });
 
-    test("quadratic isSimple, non-simple curve border case", () {
+    test('quadratic isSimple, non-simple curve border case', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 28.87), Vector2(100.0, 0.0)]);
 
       expect(curve.isSimple, isFalse);
     });
 
-    test("cubic isSimple, simple curve border case", () {
+    test('cubic isSimple, simple curve border case', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(25.0, -20.0),
@@ -474,7 +474,7 @@ void main() {
       expect(curve.isSimple, isTrue);
     });
 
-    test("cubic isSimple, non-simple curve border case", () {
+    test('cubic isSimple, non-simple curve border case', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(25.0, -20.0),
@@ -485,7 +485,7 @@ void main() {
       expect(curve.isSimple, isFalse);
     });
 
-    test("cubic isSimple, simple curve with points close together", () {
+    test('cubic isSimple, simple curve with points close together', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.5, 0.2),
@@ -496,20 +496,20 @@ void main() {
       expect(curve.isSimple, isTrue);
     });
 
-    test("quadratic isSimple, diagonal degenerate curve", () {
+    test('quadratic isSimple, diagonal degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 30.0), Vector2(50.0, 15.0)]);
       expect(curve.isSimple, isFalse);
     });
 
-    test("quadratic isSimple, horizontal degenerate curve", () {
+    test('quadratic isSimple, horizontal degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(50.0, 0.0)]);
       expect(curve.isSimple, isFalse);
     });
 
     test(
-        "cubic isSimple, diagonal degenerate curve, both control points on outside",
+        'cubic isSimple, diagonal degenerate curve, both control points on outside',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -521,7 +521,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, horizontal degenerate curve, both control points on outside",
+        'cubic isSimple, horizontal degenerate curve, both control points on outside',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -533,7 +533,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, horizontal degenerate curve, both control points going past opposite endpoint",
+        'cubic isSimple, horizontal degenerate curve, both control points going past opposite endpoint',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -545,7 +545,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, horizontal degenerate curve, one control point on outside",
+        'cubic isSimple, horizontal degenerate curve, one control point on outside',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -557,7 +557,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, horizontal degenerate curve, one control point going past opposite endpoint",
+        'cubic isSimple, horizontal degenerate curve, one control point going past opposite endpoint',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -569,7 +569,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, horizontal degenerate curve, one control point on outside, other going past opposite endpoint",
+        'cubic isSimple, horizontal degenerate curve, one control point on outside, other going past opposite endpoint',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -581,7 +581,7 @@ void main() {
     });
 
     test(
-        "quadratic isSimple, degenerate curve with control point overlapping end point",
+        'quadratic isSimple, degenerate curve with control point overlapping end point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 0.0)]);
@@ -589,7 +589,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, linear degenerate curve with one control point overlapping adjacent end point",
+        'cubic isSimple, linear degenerate curve with one control point overlapping adjacent end point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -601,7 +601,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, simple non-linear degenerate curve with one control point overlapping adjacent end point",
+        'cubic isSimple, simple non-linear degenerate curve with one control point overlapping adjacent end point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -613,7 +613,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, non-simple non-linear degenerate curve with one control point overlapping adjacent end point",
+        'cubic isSimple, non-simple non-linear degenerate curve with one control point overlapping adjacent end point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -625,7 +625,7 @@ void main() {
     });
 
     test(
-        "cubic isSimple, degenerate curve with both control points overlapping adjacent end point",
+        'cubic isSimple, degenerate curve with both control points overlapping adjacent end point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),

--- a/test/unit_tests/bezier_intersection_methods_test.dart
+++ b/test/unit_tests/bezier_intersection_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("intersectionsWithCurve", () {
-    test("quadratic intersectionsWithCurve", () {
+  group('intersectionsWithCurve', () {
+    test('quadratic intersectionsWithCurve', () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 50.0), Vector2(100.0, 0.0)]);
 
@@ -16,7 +16,7 @@ void main() {
       expect(resultB, hasLength(2));
     });
 
-    test("cubic intersectionsWithCurve", () {
+    test('cubic intersectionsWithCurve', () {
       final curveA = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.0, 50.0),
@@ -38,7 +38,7 @@ void main() {
       expect(resultB, hasLength(2));
     });
 
-    test("cubic intersectionsWithCurve with quadratic curve", () {
+    test('cubic intersectionsWithCurve with quadratic curve', () {
       final curveA = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.0, 50.0),
@@ -56,7 +56,7 @@ void main() {
       expect(resultB, hasLength(2));
     });
 
-    test("quadratic intersectionsWithCurve, one intersection", () {
+    test('quadratic intersectionsWithCurve, one intersection', () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -70,7 +70,7 @@ void main() {
       expect(resultB, hasLength(1));
     });
 
-    test("quadratic intersectionsWithCurve, two intersections", () {
+    test('quadratic intersectionsWithCurve, two intersections', () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -84,7 +84,7 @@ void main() {
       expect(resultB, hasLength(2));
     });
 
-    test("quadratic intersectionsWithCurve, four intersections", () {
+    test('quadratic intersectionsWithCurve, four intersections', () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 200.0), Vector2(100.0, 0.0)]);
 
@@ -99,7 +99,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithCurve with looped cubic near self-intersection point, two intersections",
+        'quadratic intersectionsWithCurve with looped cubic near self-intersection point, two intersections',
         () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -122,7 +122,7 @@ void main() {
       expect(resultB[1].t2, closeToDouble(0.5, 0.003));
     });
 
-    test("cubic intersectionsWithCurve, five intersections", () {
+    test('cubic intersectionsWithCurve, five intersections', () {
       final curveA = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 300.0),
@@ -144,7 +144,7 @@ void main() {
       expect(resultB, hasLength(5));
     });
 
-    test("cubic intersectionsWithCurve(), nine intersections", () {
+    test('cubic intersectionsWithCurve(), nine intersections', () {
       final curveA = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 300.0),
@@ -167,7 +167,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithCurve with other quadratic at shallow angle, one intersection with increased minTValueDifference",
+        'quadratic intersectionsWithCurve with other quadratic at shallow angle, one intersection with increased minTValueDifference',
         () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 20.0), Vector2(100.0, 100.0)]);
@@ -186,7 +186,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithCurve with other quadratic at shallow angle, one intersection with decreased curveIntersectionThreshold",
+        'quadratic intersectionsWithCurve with other quadratic at shallow angle, one intersection with decreased curveIntersectionThreshold',
         () {
       final curveA = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 20.0), Vector2(100.0, 100.0)]);
@@ -205,8 +205,8 @@ void main() {
     });
   });
 
-  group("intersectionsWithSelf", () {
-    test("cubic intersectionsWithSelf, no intersection", () {
+  group('intersectionsWithSelf', () {
+    test('cubic intersectionsWithSelf, no intersection', () {
       final points = [
         Vector2(10.0, 30.0),
         Vector2(50.0, 50.0),
@@ -219,7 +219,7 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test("cubic intersectionsWithSelf, one intersection", () {
+    test('cubic intersectionsWithSelf, one intersection', () {
       final points = [
         Vector2(0.0, 0.0),
         Vector2(200.0, 100.0),
@@ -232,7 +232,7 @@ void main() {
       expect(result, hasLength(1));
     });
 
-    test("cubic intersectionsWithSelf, one intersection again", () {
+    test('cubic intersectionsWithSelf, one intersection again', () {
       final curve = CubicBezier([
         Vector2(40.0, 0.0),
         Vector2(200.0, 100.0),
@@ -245,7 +245,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithSelf with shallow angle, one intersection with reduced curveIntersectionThreshold",
+        'cubic intersectionsWithSelf with shallow angle, one intersection with reduced curveIntersectionThreshold',
         () {
       final curve = CubicBezier([
         Vector2(10.0, 0.0),
@@ -261,9 +261,9 @@ void main() {
     });
   });
 
-  group("intersectionsWithLineSegment", () {
+  group('intersectionsWithLineSegment', () {
     test(
-        "cubic intersectionsWithLineSegment, diagonal line with two intersections",
+        'cubic intersectionsWithLineSegment, diagonal line with two intersections',
         () {
       final points = [
         Vector2(10.0, 30.0),
@@ -281,7 +281,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, diagonal line with two intersections",
+        'quadratic intersectionsWithLineSegment, diagonal line with two intersections',
         () {
       final points = [
         Vector2(10.0, 500.0),
@@ -298,7 +298,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, vertical line with single intersection",
+        'quadratic intersectionsWithLineSegment, vertical line with single intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -310,7 +310,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, horizontal line through left half, single intersection",
+        'quadratic intersectionsWithLineSegment, horizontal line through left half, single intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -322,7 +322,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, horizontal line tangent to apex, single intersection",
+        'quadratic intersectionsWithLineSegment, horizontal line tangent to apex, single intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -334,7 +334,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, horizontal line just above apex, no intersections",
+        'quadratic intersectionsWithLineSegment, horizontal line just above apex, no intersections',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -346,7 +346,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, horizontal line just below apex, two intersections",
+        'quadratic intersectionsWithLineSegment, horizontal line just below apex, two intersections',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -358,7 +358,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, horizontal line through diagonal curve, one intersection",
+        'quadratic intersectionsWithLineSegment, horizontal line through diagonal curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)]);
@@ -370,7 +370,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, vertical line through diagonal curve, one intersection",
+        'quadratic intersectionsWithLineSegment, vertical line through diagonal curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)]);
@@ -382,7 +382,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, parallel diagonal line through diagonal curve, two intersection",
+        'quadratic intersectionsWithLineSegment, parallel diagonal line through diagonal curve, two intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)]);
@@ -394,7 +394,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, perpendicular diagonal line through diagonal curve, one intersection",
+        'quadratic intersectionsWithLineSegment, perpendicular diagonal line through diagonal curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)]);
@@ -406,7 +406,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, slanted diagonal line through diagonal curve, one intersection",
+        'quadratic intersectionsWithLineSegment, slanted diagonal line through diagonal curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(100.0, 0.0), Vector2(100.0, 100.0)]);
@@ -418,7 +418,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, slanted line through linear curve, one intersection",
+        'quadratic intersectionsWithLineSegment, slanted line through linear curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(20.0, 20.0), Vector2(100.0, 100.0)]);
@@ -430,7 +430,7 @@ void main() {
     });
 
     test(
-        "quadratic intersectionsWithLineSegment, perpendicular line through linear curve, one intersection",
+        'quadratic intersectionsWithLineSegment, perpendicular line through linear curve, one intersection',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(20.0, 20.0), Vector2(100.0, 100.0)]);
@@ -442,7 +442,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line, one intersection",
+        'cubic intersectionsWithLineSegment, horizontal line, one intersection',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -458,7 +458,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line, two intersections",
+        'cubic intersectionsWithLineSegment, horizontal line, two intersections',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -474,7 +474,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line, three intersections",
+        'cubic intersectionsWithLineSegment, horizontal line, three intersections',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -489,7 +489,7 @@ void main() {
       expect(result, hasLength(3));
     });
 
-    test("cubic intersectionsWithLineSegment, vertical line, one intersection",
+    test('cubic intersectionsWithLineSegment, vertical line, one intersection',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -505,7 +505,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, vertical line with looped curve, three intersection",
+        'cubic intersectionsWithLineSegment, vertical line with looped curve, three intersection',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -521,7 +521,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, perpendicular line through linear curve, one intersection",
+        'cubic intersectionsWithLineSegment, perpendicular line through linear curve, one intersection',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -537,7 +537,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, y axis through typical curve, one intersection",
+        'cubic intersectionsWithLineSegment, y axis through typical curve, one intersection',
         () {
       final curve = CubicBezier([
         Vector2(-214.5, 80.0),
@@ -553,7 +553,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, y axis through typical curve, translated to the right, one intersection",
+        'cubic intersectionsWithLineSegment, y axis through typical curve, translated to the right, one intersection',
         () {
       final offset = 429.0;
       final curve = CubicBezier([
@@ -570,7 +570,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line through typical curve",
+        'cubic intersectionsWithLineSegment, horizontal line through typical curve',
         () {
       final curve = CubicBezier([
         Vector2(214.5, 630.0),
@@ -586,7 +586,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line through typical curve, translated up",
+        'cubic intersectionsWithLineSegment, horizontal line through typical curve, translated up',
         () {
       final offset = 6.0;
       final curve = CubicBezier([
@@ -603,7 +603,7 @@ void main() {
     });
 
     test(
-        "cubic intersectionsWithLineSegment, horizontal line through typical curve, translated down",
+        'cubic intersectionsWithLineSegment, horizontal line through typical curve, translated down',
         () {
       final offset = -6.0;
       final curve = CubicBezier([

--- a/test/unit_tests/bezier_nearest_methods_test.dart
+++ b/test/unit_tests/bezier_nearest_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("indexOfNearestPoint", () {
-    test("one point", () {
+  group('indexOfNearestPoint', () {
+    test('one point', () {
       final points = [Vector2(80.0, -40.0)];
 
       expect(indexOfNearestPoint(points, Vector2(-30.0, -30.0)), equals(0));
@@ -11,7 +11,7 @@ void main() {
       expect(indexOfNearestPoint(points, Vector2(80.0, -40.0)), equals(0));
     });
 
-    test("two points", () {
+    test('two points', () {
       final points = [Vector2(-1.0, -1.0), Vector2(1.0, 1.0)];
 
       expect(indexOfNearestPoint(points, Vector2(-1.0, -1.0)), equals(0));
@@ -24,13 +24,13 @@ void main() {
       expect(indexOfNearestPoint(points, Vector2(7.0, -200.0)), equals(0));
     });
 
-    test("equidistant solutions prefers earlier element", () {
+    test('equidistant solutions prefers earlier element', () {
       final points = [Vector2(-100.0, 0.0), Vector2(100.0, 0.0)];
 
       expect(indexOfNearestPoint(points, Vector2(0.0, 0.0)), equals(0));
     });
 
-    test("distribution a", () {
+    test('distribution a', () {
       final points = [
         Vector2(500.0, 10.0),
         Vector2(0.0, 0.0),
@@ -61,7 +61,7 @@ void main() {
       expect(indexOfNearestPoint(points, Vector2(-100.0, 0.0)), equals(1));
     });
 
-    test("from a look-up table", () {
+    test('from a look-up table', () {
       final curve = CubicBezier([
         Vector2(-100.0, 25.0),
         Vector2(-65.0, -110.0),
@@ -84,8 +84,8 @@ void main() {
     });
   });
 
-  group("nearestTValue", () {
-    test("quadratic", () {
+  group('nearestTValue', () {
+    test('quadratic', () {
       final curve = QuadraticBezier(
           [Vector2(90.0, 0.0), Vector2(-10.0, -50.0), Vector2(-45.0, 45.0)]);
 
@@ -135,7 +135,7 @@ void main() {
           closeToDouble(0.586599999999));
     });
 
-    test("quadratic, equidistant solutions prefers earlier t value", () {
+    test('quadratic, equidistant solutions prefers earlier t value', () {
       final curve = QuadraticBezier([
         Vector2(-1.0, 0.0),
         Vector2(0.0, 100.0),
@@ -146,7 +146,7 @@ void main() {
       expect(curve.nearestTValue(Vector2(0.0, 20.0)), closeToDouble(0.112));
     });
 
-    test("cubic", () {
+    test('cubic', () {
       final curve = CubicBezier([
         Vector2(-100.0, -100.0),
         Vector2(-80.0, 50.0),

--- a/test/unit_tests/bezier_offset_methods_test.dart
+++ b/test/unit_tests/bezier_offset_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("scaledCurve", () {
-    test("cubic scaledCurve", () {
+  group('scaledCurve', () {
+    test('cubic scaledCurve', () {
       final points = [
         Vector2(0.0, 0.0),
         Vector2(5.0, 15.0),
@@ -25,7 +25,7 @@ void main() {
           ]));
     });
 
-    test("quadratic scaledCurve", () {
+    test('quadratic scaledCurve', () {
       final points = [
         Vector2(10.0, 0.0),
         Vector2(30.0, 1.0),
@@ -46,7 +46,7 @@ void main() {
           ]));
     });
 
-    test("quadratic scaledCurve, linear curve", () {
+    test('quadratic scaledCurve, linear curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 50.0), Vector2(100.0, 100.0)]);
 
@@ -62,7 +62,7 @@ void main() {
           ]));
     });
 
-    test("cubic scaledCurve, parallel endpoint normals", () {
+    test('cubic scaledCurve, parallel endpoint normals', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.0, 100.0),
@@ -83,7 +83,7 @@ void main() {
           ]));
     });
 
-    test("cubic scaledCurve, parallel endpoint normals, another test", () {
+    test('cubic scaledCurve, parallel endpoint normals, another test', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 0.0),
@@ -104,7 +104,7 @@ void main() {
           ]));
     });
 
-    test("cubic scaledCurve, anti-parallel endpoint normals", () {
+    test('cubic scaledCurve, anti-parallel endpoint normals', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.0, 100.0),
@@ -126,7 +126,7 @@ void main() {
     });
 
     test(
-        "cubic scaledCurve, non-linear curve with first control point overlapping start point",
+        'cubic scaledCurve, non-linear curve with first control point overlapping start point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -148,7 +148,7 @@ void main() {
     });
 
     test(
-        "cubic scaledCurve, non-linear curve with second control point overlapping end point",
+        'cubic scaledCurve, non-linear curve with second control point overlapping end point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -170,7 +170,7 @@ void main() {
     });
 
     test(
-        "quadratic scaledCurve, linear curve with control point overlapping start point",
+        'quadratic scaledCurve, linear curve with control point overlapping start point',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(0.0, 0.0), Vector2(100.0, 0.0)]);
@@ -184,7 +184,7 @@ void main() {
     });
 
     test(
-        "cubic scaledCurve, linear curve with first control point overlapping start point",
+        'cubic scaledCurve, linear curve with first control point overlapping start point',
         () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
@@ -206,8 +206,8 @@ void main() {
     });
   });
 
-  group("toCubicBezier", () {
-    test("quadratic toCubicBezier", () {
+  group('toCubicBezier', () {
+    test('quadratic toCubicBezier', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -230,8 +230,8 @@ void main() {
     });
   });
 
-  group("offsetCurve", () {
-    test("cubic offsetCurve", () {
+  group('offsetCurve', () {
+    test('cubic offsetCurve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(15.0, 95.0),
@@ -280,7 +280,7 @@ void main() {
           ]));
     });
 
-    test("quadratic offsetCurve", () {
+    test('quadratic offsetCurve', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(20.0, 20.0),
@@ -308,7 +308,7 @@ void main() {
           ]));
     });
 
-    test("linear cubic offsetCurve", () {
+    test('linear cubic offsetCurve', () {
       final points = [
         Vector2(100.0, 100.0),
         Vector2(100.0, 200.0),
@@ -330,7 +330,7 @@ void main() {
           ]));
     });
 
-    test("linear quadratic offsetCurve", () {
+    test('linear quadratic offsetCurve', () {
       final points = [
         Vector2(0.0, 0.0),
         Vector2(20.0, 5.0),

--- a/test/unit_tests/bezier_parameter_methods_test.dart
+++ b/test/unit_tests/bezier_parameter_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("pointAt", () {
-    test("quadratic pointAt", () {
+  group('pointAt', () {
+    test('quadratic pointAt', () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
 
@@ -16,7 +16,7 @@ void main() {
           closeToVector(Vector2(28.912500381469727, 82.25)));
     });
 
-    test("cubic pointAt", () {
+    test('cubic pointAt', () {
       final curve = CubicBezier([
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -35,8 +35,8 @@ void main() {
     });
   });
 
-  group("hullPointsAt", () {
-    test("quadratic hullPointsAt", () {
+  group('hullPointsAt', () {
+    test('quadratic hullPointsAt', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -59,7 +59,7 @@ void main() {
       expect(hull2[5], closeToVector(Vector2(20.0, 32.0)));
     });
 
-    test("cubic hullPointsAt", () {
+    test('cubic hullPointsAt', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(0.0, 100.0),
@@ -94,7 +94,7 @@ void main() {
       expect(hull2[9], closeToVector(Vector2(5.6, 28.8)));
     });
 
-    test("cubic hullPointsAt, second test", () {
+    test('cubic hullPointsAt, second test', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -133,7 +133,7 @@ void main() {
           closeToVector(Vector2(24.079999923706055, 57.84000015258789)));
     });
 
-    test("quadratic hullPointsAt, second test", () {
+    test('quadratic hullPointsAt, second test', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(25.0, 20.0),
@@ -161,8 +161,8 @@ void main() {
     });
   });
 
-  group("derivativeAt", () {
-    test("quadratic derivativeAt", () {
+  group('derivativeAt', () {
+    test('quadratic derivativeAt', () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
 
@@ -179,7 +179,7 @@ void main() {
       expect(curve.derivativeAt(1.0), closeToVector(Vector2(-110.0, -30.0)));
     });
 
-    test("cubic derivativeAt", () {
+    test('cubic derivativeAt', () {
       final curve = CubicBezier([
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -202,7 +202,7 @@ void main() {
       expect(curve.derivativeAt(1.0), closeToVector(Vector2(-30.0, 180.0)));
     });
 
-    test("quadratic derivativeAt, specified cachedFirstOrderDerivativePoints",
+    test('quadratic derivativeAt, specified cachedFirstOrderDerivativePoints',
         () {
       final curve = QuadraticBezier(
           [Vector2(10.0, 10.0), Vector2(70.0, 95.0), Vector2(15.0, 80.0)]);
@@ -252,7 +252,7 @@ void main() {
           closeToVector(Vector2(-110.0, -30.0)));
     });
 
-    test("cubic derivativeAt, specified cachedFirstOrderDerivativePoints", () {
+    test('cubic derivativeAt, specified cachedFirstOrderDerivativePoints', () {
       final curve = CubicBezier([
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -307,8 +307,8 @@ void main() {
     });
   });
 
-  group("normalAt", () {
-    test("cubic normalAt", () {
+  group('normalAt', () {
+    test('cubic normalAt', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -329,7 +329,7 @@ void main() {
           closeToVector(Vector2(-0.986393928527832, -0.16439898312091827)));
     });
 
-    test("quadratic normalAt", () {
+    test('quadratic normalAt', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(25.0, 20.0),
@@ -349,7 +349,7 @@ void main() {
           closeToVector(Vector2(-0.986393928527832, -0.16439898312091827)));
     });
 
-    test("cubic normalAt, specified cachedFirstOrderDerivativePoints", () {
+    test('cubic normalAt, specified cachedFirstOrderDerivativePoints', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(30.0, 100.0),
@@ -388,7 +388,7 @@ void main() {
           closeToVector(Vector2(-0.9805806875228882, 0.1961161345243454)));
     });
 
-    test("quadratic normalAt, specified cachedFirstOrderDerivativePoints", () {
+    test('quadratic normalAt, specified cachedFirstOrderDerivativePoints', () {
       final curve = QuadraticBezier(
           [Vector2(130.0, -40.0), Vector2(110.0, 85.0), Vector2(-45.0, 170.0)]);
 
@@ -423,8 +423,8 @@ void main() {
     });
   });
 
-  group("offsetPointAt", () {
-    test("cubic offsetPointAt", () {
+  group('offsetPointAt', () {
+    test('cubic offsetPointAt', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -450,7 +450,7 @@ void main() {
           closeToVector(Vector2(25.980581283569336, 20.196115493774414)));
     });
 
-    test("quadratic offsetPointAt", () {
+    test('quadratic offsetPointAt', () {
       final points = [
         Vector2(15.0, 70.0),
         Vector2(65.0, 20.0),
@@ -475,7 +475,7 @@ void main() {
           pointD, closeToVector(Vector2(62.01771926879883, 95.53215026855469)));
     });
 
-    test("quadratic offsetPointAt, negative distance", () {
+    test('quadratic offsetPointAt, negative distance', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -493,7 +493,7 @@ void main() {
           closeToVector(Vector2(89.44271850585938, -44.72135925292969)));
     });
 
-    test("cubic offsetPointAt, negativeDistance", () {
+    test('cubic offsetPointAt, negativeDistance', () {
       final curve = CubicBezier([
         Vector2(0.0, 100.0),
         Vector2(250.0, 0.0),
@@ -515,7 +515,7 @@ void main() {
           closeToVector(Vector2(-37.139068603515625, 7.1523284912109375)));
     });
 
-    test("quadratic offsetPointAt, specified cachedFirstOrderDerivativePoints",
+    test('quadratic offsetPointAt, specified cachedFirstOrderDerivativePoints',
         () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
@@ -557,7 +557,7 @@ void main() {
           closeToVector(Vector2(91.05572509765625, -4.4721360206604)));
     });
 
-    test("cubic offsetPointAt, specified cachedFirstOrderDerivativePoints", () {
+    test('cubic offsetPointAt, specified cachedFirstOrderDerivativePoints', () {
       final curve = CubicBezier([
         Vector2(0.0, 100.0),
         Vector2(250.0, 0.0),
@@ -604,8 +604,8 @@ void main() {
     });
   });
 
-  group("positionLookUpTable", () {
-    test("quadratic positionLookUpTable, default intervalsCount", () {
+  group('positionLookUpTable', () {
+    test('quadratic positionLookUpTable, default intervalsCount', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -622,7 +622,7 @@ void main() {
       expect(table[50], closeToVector(Vector2(100.0, 0.0)));
     });
 
-    test("cubic positionLookUpTable, default intervalsCount", () {
+    test('cubic positionLookUpTable, default intervalsCount', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 100.0),

--- a/test/unit_tests/bezier_split_methods_test.dart
+++ b/test/unit_tests/bezier_split_methods_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("leftSubcurveAt", () {
-    test("quadratic leftSubcurveAt", () {
+  group('leftSubcurveAt', () {
+    test('quadratic leftSubcurveAt', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -28,7 +28,7 @@ void main() {
       expect(curve3.points[2], closeToVector(Vector2(30.0, 42.0)));
     });
 
-    test("cubic leftSubcurveAt", () {
+    test('cubic leftSubcurveAt', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -63,7 +63,7 @@ void main() {
           closeToVector(Vector2(59.400001525878906, 69.30000305175781)));
     });
 
-    test("quadratic leftSubcurveAt, t > 1.0", () {
+    test('quadratic leftSubcurveAt, t > 1.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -76,7 +76,7 @@ void main() {
               [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]));
     });
 
-    test("cubic leftSubcurveAt, t > 1.0", () {
+    test('cubic leftSubcurveAt, t > 1.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -97,14 +97,14 @@ void main() {
           ]));
     });
 
-    test("quadratic leftSubcurveAt, t == 0.0", () {
+    test('quadratic leftSubcurveAt, t == 0.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
       expect(() => curve.leftSubcurveAt(0.0), throwsArgumentError);
     });
 
-    test("cubic leftSubcurveAt, t == 0.0", () {
+    test('cubic leftSubcurveAt, t == 0.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -115,14 +115,14 @@ void main() {
       expect(() => curve.leftSubcurveAt(0.0), throwsArgumentError);
     });
 
-    test("quadratic leftSubcurveAt, t < 0.0", () {
+    test('quadratic leftSubcurveAt, t < 0.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
       expect(() => curve.leftSubcurveAt(-0.2), throwsArgumentError);
     });
 
-    test("cubic leftSubcurveAt, t < 0.0", () {
+    test('cubic leftSubcurveAt, t < 0.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -134,8 +134,8 @@ void main() {
     });
   });
 
-  group("rightSubcurveAt", () {
-    test("quadratic rightSubcurveAt", () {
+  group('rightSubcurveAt', () {
+    test('quadratic rightSubcurveAt', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -161,7 +161,7 @@ void main() {
       expect(curve3.points[2], closeToVector(Vector2(100.0, 0.0)));
     });
 
-    test("cubic rightSubcurveAt", () {
+    test('cubic rightSubcurveAt', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -196,7 +196,7 @@ void main() {
       expect(curve3.points[3], closeToVector(Vector2(100.0, 0.0)));
     });
 
-    test("quadratic rightSubcurveAt, t < 0.0", () {
+    test('quadratic rightSubcurveAt, t < 0.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
@@ -209,7 +209,7 @@ void main() {
               [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]));
     });
 
-    test("cubic rightSubcurveAt, t < 0.0", () {
+    test('cubic rightSubcurveAt, t < 0.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -230,14 +230,14 @@ void main() {
           ]));
     });
 
-    test("quadratic rightSubcurveAt, t == 1.0", () {
+    test('quadratic rightSubcurveAt, t == 1.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
       expect(() => curve.rightSubcurveAt(1.0), throwsArgumentError);
     });
 
-    test("cubic rightSubcurveAt, t == 1.0", () {
+    test('cubic rightSubcurveAt, t == 1.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -248,14 +248,14 @@ void main() {
       expect(() => curve.rightSubcurveAt(1.0), throwsArgumentError);
     });
 
-    test("quadratic rightSubcurveAt, t > 1.0", () {
+    test('quadratic rightSubcurveAt, t > 1.0', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
 
       expect(() => curve.rightSubcurveAt(1.1), throwsArgumentError);
     });
 
-    test("cubic rightSubcurveAt, t > 1.0", () {
+    test('cubic rightSubcurveAt, t > 1.0', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(150.0, 200.0),
@@ -267,8 +267,8 @@ void main() {
     });
   });
 
-  group("subcurveBetween", () {
-    test("cubic subcurveBetween", () {
+  group('subcurveBetween', () {
+    test('cubic subcurveBetween', () {
       final points = [
         Vector2(10.0, 10.0),
         Vector2(70.0, 95.0),
@@ -286,7 +286,7 @@ void main() {
       expect(curve1.points[3], closeToVector(Vector2(26.875, 55.703125)));
     });
 
-    test("quadratic subcurveBetween", () {
+    test('quadratic subcurveBetween', () {
       final points = [
         Vector2(70.0, 95.0),
         Vector2(25.0, 20.0),
@@ -306,8 +306,8 @@ void main() {
     });
   });
 
-  group("simpleSubcurves", () {
-    test("cubic simpleSubcurves", () {
+  group('simpleSubcurves', () {
+    test('cubic simpleSubcurves', () {
       final points = [
         Vector2(105.0, -70.0),
         Vector2(50.0, 50.0),
@@ -365,7 +365,7 @@ void main() {
           ]));
     });
 
-    test("quadratic simpleSubcurves", () {
+    test('quadratic simpleSubcurves', () {
       final points = [
         Vector2(50.0, 50.0),
         Vector2(10.0, 80.0),
@@ -401,7 +401,7 @@ void main() {
           ]));
     });
 
-    test("quadratic simpleSubcurves, second test", () {
+    test('quadratic simpleSubcurves, second test', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(50.0, 100.0), Vector2(100.0, 0.0)]);
       final result = curve.simpleSubcurves();
@@ -441,7 +441,7 @@ void main() {
           ]));
     });
 
-    test("cubic simpleSubcurves, wavy curve", () {
+    test('cubic simpleSubcurves, wavy curve', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 20.0),
@@ -452,7 +452,7 @@ void main() {
       expect(result, hasLength(4));
     });
 
-    test("cubic simpleSubcurves, arched curve", () {
+    test('cubic simpleSubcurves, arched curve', () {
       final curve = CubicBezier([
         Vector2(0.0, 0.0),
         Vector2(50.0, 20.0),
@@ -463,7 +463,7 @@ void main() {
       expect(result, hasLength(2));
     });
 
-    test("quadratic simpleSubcurves, linear curve", () {
+    test('quadratic simpleSubcurves, linear curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(5.0, 5.0), Vector2(100.0, 100.0)]);
 
@@ -476,7 +476,7 @@ void main() {
               [Vector2(0.0, 0.0), Vector2(5.0, 5.0), Vector2(100.0, 100.0)]));
     });
 
-    test("quadratic simpleSubcurves, degenerate curve", () {
+    test('quadratic simpleSubcurves, degenerate curve', () {
       final curve = QuadraticBezier(
           [Vector2(0.0, 0.0), Vector2(250.0, 250.0), Vector2(100.0, 100.0)]);
 

--- a/test/unit_tests/even_spacer_test.dart
+++ b/test/unit_tests/even_spacer_test.dart
@@ -1,8 +1,8 @@
-import "../testing_tools/testing_tools.dart";
+import '../testing_tools/testing_tools.dart';
 
 void main() {
-  group("constructor", () {
-    test("constructor with three-entry look up table", () {
+  group('constructor', () {
+    test('constructor with three-entry look up table', () {
       final lookUpTable = <Vector2>[
         Vector2(0.0, 0.0),
         Vector2(2.0, 0.0),
@@ -12,32 +12,32 @@ void main() {
       expect(object, TypeMatcher<EvenSpacer>());
     });
 
-    test("constructor with two-entry look up table", () {
+    test('constructor with two-entry look up table', () {
       final lookUpTable = <Vector2>[Vector2(0.0, 0.0), Vector2(100.0, 100.0)];
 
       final object = EvenSpacer(lookUpTable);
       expect(object, TypeMatcher<EvenSpacer>());
     });
 
-    test("constructor throws error with one-entry look up table", () {
+    test('constructor throws error with one-entry look up table', () {
       final lookUpTable = <Vector2>[Vector2(100.0, 100.0)];
       expect(() => EvenSpacer(lookUpTable), throwsA(TypeMatcher<Error>()));
     });
 
-    test("constructor throws error with empty look up table", () {
+    test('constructor throws error with empty look up table', () {
       expect(() => EvenSpacer([]), throwsA(TypeMatcher<Error>()));
     });
   });
 
-  group("arcLength getter", () {
-    test("arcLength, two-entry look up table", () {
+  group('arcLength getter', () {
+    test('arcLength, two-entry look up table', () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(100.0, 100.0)]);
       final result = arcLengthCalculator.arcLength;
       expect(result, closeToDouble(141.4213562373095));
     });
 
-    test("arcLength, three-entry look up table", () {
+    test('arcLength, three-entry look up table', () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(3.0, 0.0), Vector2(3.0, 1.0)]);
       final result = arcLengthCalculator.arcLength;
@@ -45,8 +45,8 @@ void main() {
     });
   });
 
-  group("evenTValueAt()", () {
-    test("evenTValueAt(), portion at border of or outside normal range", () {
+  group('evenTValueAt()', () {
+    test('evenTValueAt(), portion at border of or outside normal range', () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(3.0, 0.0), Vector2(3.0, 1.0)]);
 
@@ -63,7 +63,7 @@ void main() {
       expect(result4, closeToDouble(1.0));
     });
 
-    test("evenTValueAt(), portion in normal range, three-entry look up table",
+    test('evenTValueAt(), portion in normal range, three-entry look up table',
         () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(3.0, 0.0), Vector2(3.0, 1.0)]);
@@ -81,8 +81,8 @@ void main() {
     });
   });
 
-  group("evenTValues", () {
-    test("default parametersCount", () {
+  group('evenTValues', () {
+    test('default parametersCount', () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(3.0, 0.0), Vector2(3.0, 1.0)]);
 
@@ -96,7 +96,7 @@ void main() {
       expect(result[50], closeToDouble(1.0));
     });
 
-    test("parametersCount of 100", () {
+    test('parametersCount of 100', () {
       final arcLengthCalculator =
           EvenSpacer([Vector2(0.0, 0.0), Vector2(3.0, 0.0), Vector2(3.0, 1.0)]);
 


### PR DESCRIPTION
Switching the entire library to use single quotes instead of double quotes.  😖  They updated the style recommendations again, so I guess we should conform.  💁‍♂ ✅ 

I also fixed a spot where Pub started complaining that we used `List()` instead of `[]`.  🔧

Bumping the version number to `1.1.5`.  🆙 