### PR TITLE
Improved accuracy of nearestTValue at ends

### DIFF
--- a/lib/src/bezier.dart
+++ b/lib/src/bezier.dart
@@ -746,15 +746,9 @@ abstract class Bezier {
 
     final maxIndex = lookUpTable.length - 1;
 
-    if (index == 0) {
-      return 0.0;
-    } else if (index == maxIndex) {
-      return 1.0;
-    }
-
     final intervalsCount = maxIndex.toDouble();
-    final t1 = (index - 1) / intervalsCount;
-    final t2 = (index + 1) / intervalsCount;
+    final t1 = max(0.0, (index - 1) / intervalsCount);
+    final t2 = min(1.0, (index + 1) / intervalsCount);
 
     final tIncrement = stepSize / intervalsCount;
     final maxT = t2 + tIncrement;


### PR DESCRIPTION
Currently, nearestTValue snaps to 0.0 or 1.0 when getting close to the ends instead of performing the approximation. This is particularly an issue for longer Bezier curves where this can create noticeable issues in real applications.

This pull request fixes this and ensures that the approximation is performed even close to the ends.